### PR TITLE
Add function to list unresolved incidents from status page

### DIFF
--- a/incidents.go
+++ b/incidents.go
@@ -44,7 +44,7 @@ func (request BaseRequest) ListIncidents(searchQuery string) (string, []Incident
 	return res.Status, structuredResponse
 }
 
-// ListIncidents executes a request and return a list of unresolved incidents at Statuspage
+// ListUnresolvedIncidents executes a request and return a list of unresolved incidents at Statuspage
 func (request BaseRequest) ListUnresolvedIncidents() (string, []IncidentsResponse) {
 	body := ""
 

--- a/incidents.go
+++ b/incidents.go
@@ -44,6 +44,29 @@ func (request BaseRequest) ListIncidents(searchQuery string) (string, []Incident
 	return res.Status, structuredResponse
 }
 
+// ListIncidents executes a request and return a list of unresolved incidents at Statuspage
+func (request BaseRequest) ListUnresolvedIncidents() (string, []IncidentsResponse) {
+	body := ""
+
+	URL := request.URL + "/incidents/unresolved"
+	finalRequest := request.mountRequest(URL, "GET", request.Headers, body)
+
+	res, err := finalRequest.exec()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	jsonData, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var structuredResponse []IncidentsResponse
+	json.Unmarshal([]byte(jsonData), &structuredResponse)
+
+	return res.Status, structuredResponse
+}
+
 // GetIncident retrieve information about a specific incident
 func (request BaseRequest) GetIncident(incidentID string) (string, IncidentsResponse) {
 	URL := request.URL + "/incidents/" + incidentID

--- a/incidents_test.go
+++ b/incidents_test.go
@@ -50,6 +50,22 @@ func TestListIncidents(t *testing.T) {
 	assert.Equal(t, "200 OK", status)
 }
 
+func TestListUnresolvedIncidents(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "OAuth "+apiKey, r.Header.Get("Authorization"))
+		assert.Equal(t, "GET", r.Method)
+		w.Write([]byte(okResponse))
+	})
+	testServer := httptest.NewServer(h)
+
+	statuspage := Connect(pageID, apiKey)
+	statuspage.URL = "http://" + testServer.Listener.Addr().String()
+
+	status, _ := statuspage.ListUnresolvedIncidents()
+
+	assert.Equal(t, "200 OK", status)
+}
+
 func TestGetIncidents(t *testing.T) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "OAuth "+apiKey, r.Header.Get("Authorization"))


### PR DESCRIPTION
Add function to list only open incidents because retrieve closed incidents will make the request slower as the number of previous incidents increase